### PR TITLE
Fix/err

### DIFF
--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -119,7 +119,7 @@ func TestBLS_DeserializationG1(t *testing.T) {
 		err := pub.Deserialize(obj.Input.Pubkey)
 
 		if name == "deserialization_succeeds_infinity_with_true_b_flag.json" {
-			// we also fail if point is at inifinity
+			// we also fail if point is at infinity
 			return
 		}
 

--- a/spec/spec_test.go
+++ b/spec/spec_test.go
@@ -40,7 +40,7 @@ func TestPresetMainnet(t *testing.T) {
 		key = strings.Title(key)
 
 		if val, ok := specOut[key]; ok {
-			// avoid uint8 and int comparisions by using the fmt.Sprinot to format
+			// avoid uint8 and int comparisons by using the fmt.Sprinot to format
 			require.Equal(t, fmt.Sprintf("%d", val), fmt.Sprintf("%d", presetVal))
 		}
 	}


### PR DESCRIPTION
# Fix: Corrected typos in source files

## Changes
1. **Corrected typo in `bls/bls_test.go:122`**:
   - "inifinity" corrected to "infinity".

2. **Corrected typo in `spec/spec_test.go:43`**:
   - "comparisions" corrected to "comparisons".

## Purpose
- Improved code accuracy and professionalism by fixing typos.

